### PR TITLE
Blitzy Handoff: setup docs + manifest + checklist; add Merge & Kick steps

### DIFF
--- a/.github/workflows/cd-ai-broker.yml
+++ b/.github/workflows/cd-ai-broker.yml
@@ -1,0 +1,158 @@
+name: CD - AI Broker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/ai-broker/**'
+      - '.github/workflows/cd-ai-broker.yml'
+  workflow_dispatch:
+
+env:
+  GCP_REGION: us-central1
+  GAR_REPO: veria
+  SERVICE_NAME: ai-broker
+  IMAGE_BASE: us-central1-docker.pkg.dev/veria-dev/veria/ai-broker
+
+jobs:
+  deploy:
+    name: Build and Deploy AI Broker
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Configure Docker for Artifact Registry
+        run: |
+          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate image metadata
+        id: meta
+        run: |
+          SHA_TAG="${{ env.IMAGE_BASE }}:${GITHUB_SHA}"
+          echo "sha_tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+          echo "tags=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Create ai-broker specific Dockerfile
+        run: |
+          cat > services/ai-broker/Dockerfile << 'EOF'
+          FROM node:20-alpine AS builder
+          RUN corepack enable && corepack prepare pnpm@latest --activate
+          WORKDIR /app
+
+          # Copy package files
+          COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+          COPY services/ai-broker/package.json ./services/ai-broker/
+
+          # Install dependencies
+          RUN pnpm install --frozen-lockfile --filter=ai-broker...
+
+          # Copy source
+          COPY services/ai-broker/ ./services/ai-broker/
+
+          # Build
+          RUN pnpm --filter=ai-broker build
+
+          # Production stage
+          FROM node:20-alpine
+          RUN corepack enable && corepack prepare pnpm@latest --activate
+          RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001
+
+          WORKDIR /app
+
+          # Copy built application
+          COPY --from=builder --chown=nodejs:nodejs /app/services/ai-broker/package.json ./
+          COPY --from=builder --chown=nodejs:nodejs /app/services/ai-broker/dist ./dist
+          COPY --from=builder --chown=nodejs:nodejs /app/node_modules ./node_modules
+
+          USER nodejs
+          ENV NODE_ENV=production
+          ENV PORT=4001
+          EXPOSE 4001
+
+          HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+            CMD node -e "require('http').get('http://localhost:4001/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+
+          CMD ["node", "dist/index.js"]
+          EOF
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: ./services/ai-broker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(gcloud artifacts docker images describe "${{ steps.meta.outputs.sha_tag }}" \
+            --format='get(image_summary.digest)')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "Image digest: ${DIGEST}"
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        run: |
+          # Deploy using the image digest for immutability
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image="${{ env.IMAGE_BASE }}@${{ steps.digest.outputs.digest }}" \
+            --region=${{ env.GCP_REGION }} \
+            --platform=managed \
+            --port=4001 \
+            --min-instances=0 \
+            --max-instances=10 \
+            --cpu=1 \
+            --memory=512Mi \
+            --timeout=60 \
+            --concurrency=80 \
+            --service-account=${{ secrets.GCP_SA_EMAIL }} \
+            --no-allow-unauthenticated \
+            --set-env-vars="NODE_ENV=production" \
+            --update-labels="commit-sha=${GITHUB_SHA},deployed-by=github-actions,service=ai-broker" \
+            --format="value(status.url)"
+
+      - name: Verify deployment
+        run: |
+          echo "Deployment completed successfully!"
+          echo ""
+          echo "Service details:"
+          gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region=${{ env.GCP_REGION }} \
+            --format="yaml(status.url,status.latestReadyRevisionName,status.traffic)"
+
+      - name: Output deployment summary
+        run: |
+          echo "## 🚀 AI Broker Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Service**: ${{ env.SERVICE_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Region**: ${{ env.GCP_REGION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: ${{ env.IMAGE_BASE }}@${{ steps.digest.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit**: ${GITHUB_SHA}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Deployment successful!" >> $GITHUB_STEP_SUMMARY

--- a/BLITZY_SETUP.md
+++ b/BLITZY_SETUP.md
@@ -1,83 +1,185 @@
-# Blitzy Setup — Veria (dev)
+# Blitzy Setup - Veria OIDC/WIF Deployment
 
-## Constants
-- PROJECT_ID: `veria-dev`
-- REGION: `us-central1`
-- AR_REPO: `veria`
-- SERVICE_NAME: `veria-hello`
-- SERVICE_URL: `https://veria-hello-<hash>-uc.a.run.app`
+## Project Configuration
 
-## One-time local sanity
+- **GCP Project**: veria-dev
+- **Project Number**: 190356591245
+- **Region**: us-central1
+- **Monorepo Manager**: pnpm workspaces
+
+## WIF (Workload Identity Federation) Setup
+
+### Pool & Provider
+- **WIF Pool**: github-pool (ACTIVE)
+- **WIF Provider**: github-provider (ACTIVE)
+- **Provider Condition**: `repository == "PROACTIVA-US/Veria" AND (ref startsWith "refs/heads/main" OR ref startsWith "refs/tags/")`
+
+### Service Account
+- **CI Service Account**: veria-automation@veria-dev.iam.gserviceaccount.com
+- **Roles**:
+  - roles/run.admin
+  - roles/iam.serviceAccountUser
+  - roles/artifactregistry.writer
+
+### GitHub Secrets (Already Configured)
+- `GCP_PROJECT_ID` = veria-dev
+- `GCP_SA_EMAIL` = veria-automation@veria-dev.iam.gserviceaccount.com
+- `WORKLOAD_IDENTITY_PROVIDER` = projects/190356591245/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+
+## Image Build & Deploy
+
+### Artifact Registry
+- **Repository**: us-central1-docker.pkg.dev/veria-dev/veria
+- **Build Target**: linux/amd64
+- **Deploy Method**: BY DIGEST ONLY (not :latest)
+
+### Cloud Run Services
+- **ai-broker**: AI suggestion service (port 4001)
+- **veria-app**: Main application (port 8080)
+- **veria-hello**: Hello world service (port 8080)
+
+## Merge & Kick Steps (One-Screen Guide)
+
+### 1. Merge PR
 ```bash
-# Verify setup
-./scripts/verify-all.sh || true
+# Check PR status
+gh pr status
 
-# Images must be built for linux/amd64
+# Merge (if checks pass or with admin override)
+gh pr merge <PR_NUMBER> --squash --delete-branch
 ```
 
-## Build & Push (local)
+### 2. Trigger CD
+Option A - Push to main (automatic on merge):
 ```bash
-# Build and push linux/amd64 image with buildx
-docker buildx build \
-  --platform linux/amd64 \
-  --tag us-central1-docker.pkg.dev/veria-dev/veria/veria-hello:$(git rev-parse --short HEAD) \
-  --push \
-  services/hello
-
-# Get digest for deployment (avoid :latest drift)
-DIGEST=$(gcloud artifacts docker images describe \
-  us-central1-docker.pkg.dev/veria-dev/veria/veria-hello:$(git rev-parse --short HEAD) \
-  --format='get(image_summary.digest)')
-
-# Deploy with digest
-gcloud run deploy veria-hello --image="us-central1-docker.pkg.dev/veria-dev/veria/veria-hello@$DIGEST" --region=us-central1
-```
-**Note:** Always deploy by digest (@sha256:...) to avoid :latest drift
-
-## Terraform (dev)
-```bash
-terraform -chdir=infra/dev init
-terraform -chdir=infra/dev apply -var-file=dev.tfvars -auto-approve
-terraform -chdir=infra/dev output  # Confirm hello_url and health_url
-```
-Outputs: `hello_url`, `health_url`
-
-## Access model (PRIVATE)
-Service requires Google ID token for invocation:
-```bash
-SERVICE_URL=$(gcloud run services describe veria-hello --region us-central1 --format='value(status.url)')
-ID_TOKEN=$(gcloud auth print-identity-token)  # For local users; CI/CD uses WIF automatically
-curl -i -H "Authorization: Bearer $ID_TOKEN" "$SERVICE_URL/_ah/health"
+git checkout main
+git pull origin main
+# CD triggers automatically
 ```
 
-## Health & Smoke
-- Health endpoint: `/_ah/health` → 200 "ok"
-- Smoke script: `scripts/blitzy-smoke.sh` (uses gcloud user ID token)
-- Example: `./scripts/blitzy-smoke.sh`
+Option B - Create release tag:
+```bash
+git tag -a v0.1.2 -m "Release: your description"
+git push origin v0.1.2
+```
 
-## CI/CD (Dev)
-- Workflow: `.github/workflows/build-deploy-smoke-dev.yml`
-- Auth: **Workload Identity Federation (GitHub OIDC)** — no JSON key (`GCP_SA_KEY`) required, uses OIDC/WIF only
-- Workflow permissions: `id-token: write`, `contents: read`
-- Steps:
-  1. Buildx → **linux/amd64**
-  2. Push AR with commit SHA tag
-  3. Resolve **@digest** and deploy Cloud Run by digest
-  4. Smoke `/_ah/health`
-- Required repo secrets:
-  - `GCP_WIF_PROVIDER` (e.g., `projects/<number>/locations/global/workloadIdentityPools/github-pool/providers/github-provider`)
-  - `GCP_WIF_SERVICE_ACCOUNT` (e.g., `veria-deployer@veria-dev.iam.gserviceaccount.com`)
+### 3. Verify Deployment
+```bash
+# Set project
+gcloud config set project veria-dev
 
-## Prod
-- PROJECT_ID: `veria-prod` (same region/service)
-- Workflow: `.github/workflows/build-deploy-smoke-prod.yml`
-- Required prod secrets: `GCP_WIF_PROVIDER_PROD`, `GCP_WIF_SERVICE_ACCOUNT_PROD`
-- Same health/smoke conventions
-- **Note:** Terraform for prod must exist in repo before prod workflow can be applied
+# Check service status
+gcloud run services describe ai-broker \
+  --region=us-central1 \
+  --format='yaml(status.url,status.latestReadyRevisionName,status.traffic)'
+
+# Get service URL
+SERVICE_URL=$(gcloud run services describe ai-broker \
+  --region=us-central1 \
+  --format='value(status.url)')
+echo "Service URL: $SERVICE_URL"
+```
+
+### 4. Smoke Test (if public)
+```bash
+# Health check
+curl -sSf "$SERVICE_URL/health" || echo "Service is private or unavailable"
+
+# API test (if public)
+curl -sSf -X POST "$SERVICE_URL/ai/graph/suggest" \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"test","provider":"local"}' || echo "Service is private"
+```
+
+### 5. Rollback (if needed)
+```bash
+# List revisions
+gcloud run revisions list \
+  --service=ai-broker \
+  --region=us-central1 \
+  --format='table(name,traffic)'
+
+# Rollback to previous revision (replace REVISION_NAME)
+gcloud run services update-traffic ai-broker \
+  --region=us-central1 \
+  --to-revisions=REVISION_NAME=100
+```
+
+## CI/CD Workflows
+
+### Main CD Workflow
+- **File**: `.github/workflows/cd.yml`
+- **Triggers**: push to main, tags v*.*.*
+- **Auth**: google-github-actions/auth@v2 with OIDC/WIF
+- **Build**: Docker buildx for linux/amd64
+- **Deploy**: Cloud Run by digest
+
+### OIDC Smoketest
+- **File**: `.github/workflows/oidc-smoketest.yml`
+- **Purpose**: Verify WIF authentication works
+- **Trigger**: manual (workflow_dispatch)
+
+## Monitoring
+
+### Cloud Logging
+```
+# Log Explorer filter for ai-broker
+resource.type="cloud_run_revision"
+AND resource.labels.service_name="ai-broker"
+AND timestamp >= "2025-01-01T00:00:00Z"
+```
+
+### GitHub Actions
+- View runs: `gh run list --workflow=cd.yml`
+- Watch run: `gh run watch <RUN_ID>`
+- View logs: `gh run view <RUN_ID> --log`
+
+## Access Control
+
+### Private Service (Default)
+Services are private by default. To test with authentication:
+```bash
+SERVICE_URL=$(gcloud run services describe ai-broker --region=us-central1 --format='value(status.url)')
+ID_TOKEN=$(gcloud auth print-identity-token --audiences="$SERVICE_URL")
+curl -H "Authorization: Bearer $ID_TOKEN" "$SERVICE_URL/health"
+```
+
+### Make Service Public (Optional)
+```bash
+gcloud run services add-iam-policy-binding ai-broker \
+  --region=us-central1 \
+  --member="allUsers" \
+  --role="roles/run.invoker"
+```
+
+### Revoke Public Access
+```bash
+gcloud run services remove-iam-policy-binding ai-broker \
+  --region=us-central1 \
+  --member="allUsers" \
+  --role="roles/run.invoker"
+```
 
 ## Troubleshooting
-- **Image not found** → push to AR or use digest
-- **amd64 required** → build with buildx `--platform linux/amd64`
-- **Private 401** → use ID token; verify invoker IAM
-- **Startup timeout** → ensure server listens on `$PORT` (8080)
-- **404 on `/healthz`** → use `/_ah/health`
+
+### Authentication Issues
+1. Verify secrets: `gh secret list`
+2. Run OIDC smoketest: `gh workflow run oidc-smoketest.yml`
+3. Check WIF provider: `cd infra/ci && ./verify-wif.sh`
+
+### Build Failures
+1. Check individual service: `pnpm --filter ai-broker build`
+2. Run tests: `pnpm --filter ai-broker test`
+3. TypeScript check: `pnpm --filter ai-broker typecheck`
+
+### Deployment Issues
+1. Check IAM: Service account needs roles/run.admin
+2. Verify image digest in Cloud Run console
+3. Check Cloud Run logs in Log Explorer
+
+## Notes
+- **OIDC/WIF Only**: No JSON keys used anywhere
+- **Deploy by Digest**: All deployments use image digest, not tags
+- **Branch Protection**: main branch can be overridden with admin
+- **Auth**: Workload Identity Federation via GitHub OIDC tokens
+- **Monorepo**: Some services may have build issues; deploy individually if needed

--- a/handoff/checklist.md
+++ b/handoff/checklist.md
@@ -1,0 +1,113 @@
+# Blitzy Handoff Checklist
+
+## Pre-Deploy Verification
+
+- [ ] Confirm GitHub secrets are present:
+  ```bash
+  gh secret list
+  # Should show: GCP_PROJECT_ID, GCP_SA_EMAIL, WORKLOAD_IDENTITY_PROVIDER
+  ```
+
+- [ ] Re-run OIDC smoketest workflow:
+  ```bash
+  gh workflow run oidc-smoketest.yml
+  gh run list --workflow=oidc-smoketest.yml --limit=1
+  ```
+
+## Deployment
+
+- [ ] Trigger CD (push to main or create tag):
+  ```bash
+  # Option 1: Push to main
+  git push origin main
+
+  # Option 2: Create release tag
+  git tag -a v0.1.3 -m "Release description"
+  git push origin v0.1.3
+  ```
+
+- [ ] Monitor CD workflow:
+  ```bash
+  gh run list --workflow=cd.yml --limit=1
+  gh run watch <RUN_ID>
+  ```
+
+## Post-Deploy Verification
+
+- [ ] Record deployment details:
+  ```bash
+  # Get image digest
+  gcloud artifacts docker images list \
+    --repository=veria \
+    --location=us-central1 \
+    --format='table(digest,tags)' \
+    --limit=1
+
+  # Get revision name
+  gcloud run services describe ai-broker \
+    --region=us-central1 \
+    --format='value(status.latestReadyRevisionName)'
+
+  # Get service URL
+  gcloud run services describe ai-broker \
+    --region=us-central1 \
+    --format='value(status.url)'
+
+  # Get traffic split
+  gcloud run services describe ai-broker \
+    --region=us-central1 \
+    --format='yaml(status.traffic)'
+  ```
+
+- [ ] Confirm Cloud Logging shows runs for ai-broker:
+  ```bash
+  gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=ai-broker" \
+    --limit=10 \
+    --format='table(timestamp,severity,textPayload)'
+  ```
+
+## Testing (if service is public)
+
+- [ ] Test health endpoint:
+  ```bash
+  SERVICE_URL=$(gcloud run services describe ai-broker --region=us-central1 --format='value(status.url)')
+  curl -sSf "$SERVICE_URL/health"
+  ```
+
+- [ ] Test API endpoint:
+  ```bash
+  curl -sSf -X POST "$SERVICE_URL/ai/graph/suggest" \
+    -H 'Content-Type: application/json' \
+    -d '{"prompt":"test","provider":"local"}'
+  ```
+
+## Rollback Plan
+
+- [ ] If issues occur, rollback to previous revision:
+  ```bash
+  # List all revisions
+  gcloud run revisions list \
+    --service=ai-broker \
+    --region=us-central1 \
+    --format='table(name,traffic,createTime)'
+
+  # Rollback (replace PREVIOUS_REVISION with actual name)
+  gcloud run services update-traffic ai-broker \
+    --region=us-central1 \
+    --to-revisions=PREVIOUS_REVISION=100
+  ```
+
+## Success Criteria
+
+- [ ] CD workflow completes successfully
+- [ ] New Cloud Run revision is serving 100% traffic
+- [ ] Health check returns 200 OK (if public)
+- [ ] No errors in Cloud Logging
+- [ ] Service responds to requests (if public)
+
+## Notes
+
+- All deployments use OIDC/WIF (no JSON keys)
+- Images are deployed by digest only
+- Service is private by default (requires authentication)
+- To make public: Add allUsers with roles/run.invoker

--- a/handoff/handoff_manifest.json
+++ b/handoff/handoff_manifest.json
@@ -1,0 +1,12 @@
+{
+  "projectId": "veria-dev",
+  "projectNumber": "190356591245",
+  "region": "us-central1",
+  "service": "ai-broker",
+  "wifPool": "github-pool",
+  "wifProvider": "github-provider",
+  "ciServiceAccount": "veria-automation@veria-dev.iam.gserviceaccount.com",
+  "ghSecrets": ["GCP_PROJECT_ID", "GCP_SA_EMAIL", "WORKLOAD_IDENTITY_PROVIDER"],
+  "triggers": ["push:main", "tag:v*.*.*"],
+  "deployByDigest": true
+}


### PR DESCRIPTION
## Summary
Comprehensive Blitzy handoff bundle with OIDC/WIF configuration, deployment docs, and dedicated ai-broker CD workflow.

## Changes

### Documentation
- **BLITZY_SETUP.md**: Complete WIF setup guide with merge & kick steps
  - Project config: veria-dev (190356591245)
  - WIF pool/provider details
  - One-screen deployment guide
  - Rollback instructions

### Handoff Bundle
- **handoff/handoff_manifest.json**: Machine-readable config
  - All WIF/OIDC details
  - GitHub secrets list
  - Deploy triggers and settings
  
- **handoff/checklist.md**: Step-by-step verification
  - Pre-deploy checks
  - Deployment commands
  - Post-deploy verification
  - Rollback plan

### CI/CD Enhancement
- **.github/workflows/cd-ai-broker.yml**: Dedicated ai-broker deployment
  - Builds only ai-broker service (avoids monorepo build issues)
  - Uses OIDC/WIF authentication
  - Deploys by digest only
  - Optimized Dockerfile for single service

## Verification Commands

```bash
# Check WIF setup
cd infra/ci && ./verify-wif.sh

# Test OIDC auth
gh workflow run oidc-smoketest.yml

# Deploy ai-broker
gh workflow run cd-ai-broker.yml

# Verify deployment
gcloud run services describe ai-broker \
  --region=us-central1 \
  --format='yaml(status.url,status.latestReadyRevisionName)'
```

## Notes
- No JSON keys used anywhere
- All deployments use image digest
- ai-broker can now deploy independently
- Main CD workflow still needs fixes for other services

🤖 Generated with [Claude Code](https://claude.ai/code)